### PR TITLE
Fix broken CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@ html, body, #root {
   -moz-osx-font-smoothing: grayscale;
 }
 
-.ms-container{
+.ms-container {
   overflow: auto;
   scroll-snap-type: y mandatory;
   overscroll-behavior-x: contain;
@@ -32,6 +32,6 @@ html, body, #root {
   scroll-snap-stop: always !important;
 }
 
-.ms-item div {
+.ms-item > div {
   height: 100%;
 }


### PR DESCRIPTION
I use [swiperjs](https://swiperjs.com) on react-mega-scroll pages, and the `.ms-item div` CSS selector applies 100% height to all child divs. It completely breaks the layout.